### PR TITLE
Add discoverable_entity_bundle_classes_taxonomy module.

### DIFF
--- a/modules/discoverable_entity_bundle_classes_taxonomy/discoverable_entity_bundle_classes_taxonomy.info.yml
+++ b/modules/discoverable_entity_bundle_classes_taxonomy/discoverable_entity_bundle_classes_taxonomy.info.yml
@@ -1,0 +1,9 @@
+name: 'Discoverable Entity Bundle Classes - Taxonomy'
+description: 'Provides support for derived taxonomy entity type classes.'
+type: module
+core: 8.x
+version: 8.x-1.0
+
+dependencies:
+  - discoverable_entity_bundle_classes
+  - taxonomy

--- a/modules/discoverable_entity_bundle_classes_taxonomy/discoverable_entity_bundle_classes_taxonomy.module
+++ b/modules/discoverable_entity_bundle_classes_taxonomy/discoverable_entity_bundle_classes_taxonomy.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Provides support for derived taxonomy entity type classes.
+ */
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function discoverable_entity_bundle_classes_taxonomy_entity_type_alter(array &$entity_types) {
+  if (isset($entity_types['taxonomy_term'])) {
+    $entity_types['taxonomy_term']->setStorageClass('\Drupal\discoverable_entity_bundle_classes\Storage\Taxonomy\TermStorage');
+  }
+}


### PR DESCRIPTION
This makes it easier to extend taxonomy by simply adding a module dependency, similar to how the paragraphs module is done.