### PR TITLE
#issue-15: Allow the class to be altered

### DIFF
--- a/src/ContentEntityBundleClassManager.php
+++ b/src/ContentEntityBundleClassManager.php
@@ -40,6 +40,8 @@ class ContentEntityBundleClassManager extends DefaultPluginManager implements Co
       'Drupal\discoverable_entity_bundle_classes\ContentEntityBundleClassInterface',
       'Drupal\discoverable_entity_bundle_classes\Annotation\ContentEntityBundleClass'
     );
+
+    $this->alterInfo('discoverable_entity_bundle_classes');
     $this->setCacheBackend($cache_backend, 'content_entity_bundle_class_plugins');
 
     // @todo: get this into a service arg.


### PR DESCRIPTION
Plugin managers should call alterInfo() in the contructor. This exists in an older version of the module that we have, but doesn't exist in the version here.

https://www.drupal.org/docs/drupal-apis/plugin-api/creating-your-own-plugin-manager